### PR TITLE
allow themer variables to specify default values

### DIFF
--- a/test/themer_replace.original.txt
+++ b/test/themer_replace.original.txt
@@ -1,0 +1,6 @@
+Replaced val (should be "val"): {{key1}}
+This line should not exist: {{!key2}}
+Default val (should be "default"): {{key3|default}}
+Default with explicit value (should be "val2"): {{key4|default}}
+Default kibosh (should not exist): {{!key5|default2}}
+

--- a/test/themer_replace.txt
+++ b/test/themer_replace.txt
@@ -1,0 +1,4 @@
+Replaced val (should be "val"): val
+Default val (should be "default"): default
+Default with explicit value (should be "val2"): val2
+

--- a/test/themer_test.zsh
+++ b/test/themer_test.zsh
@@ -1,0 +1,6 @@
+source ./theme/themer.zsh
+TEST_FILE=./test/themer_replace.txt
+
+themer_substitute key1 val $TEST_FILE
+themer_substitute key4 val2 $TEST_FILE
+themer_cleanup $TEST_FILE

--- a/theme/themer.zsh
+++ b/theme/themer.zsh
@@ -1,6 +1,11 @@
 THEMER_EMPTY_STRING='[____]'
 
 # Replaces all occurrences of a template variable within a file
+#   Accepted patterns:
+#     {{key}}                Allow value to be substituted for "key"
+#     {{!key}}               Remove entire line if no value is substituted for "key"
+#     {{key|my_default}}     Use "my_default" if no value is substituted for "key"
+#     {{!key|my_default}}    Use "my_default" if no value is substituted for "key" and remove line if no value is substituted
 function themer_substitute {
   local key=$1
   local value=$2
@@ -12,17 +17,16 @@ function themer_substitute {
     value=''
   fi
 
-
-  local pattern="{{$key}}"
-  local kibosh_pattern="{{!$key}}"
+  local pattern="\{\{$key(\|[^}]+)?\}\}" # sed -E 's/\{\{key(\|[^}]+)?\}\}/val/g'
+  local kibosh_pattern="\{\{\!$key(\|[^}]+)?\}\}"
 
   if [[ ! -z $value ]]; then # don't do replacements with empty values or the variables won't be available for cleanup
     if [[ $value == $THEMER_EMPTY_STRING ]]; then # Since shell scripting sucks, if value is '' it'll still be considered null which will break intended functionality. As a lame workaround, use a special value to represent an intended empty string :(
       value=''
     fi
 
-    sed -i -- "s&$pattern&$value&g" $file &> /dev/null
-    sed -i -- "s&$kibosh_pattern&$value&g" $file &> /dev/null
+    sed -E -i -- "s&$pattern&$value&g" $file &> /dev/null
+    sed -E -i -- "s&$kibosh_pattern&$value&g" $file &> /dev/null
   fi
 }
 
@@ -36,10 +40,15 @@ function themer_validate {
   fi
 }
 
-# Remove all unreplaced template variables
+# Apply any default values and remove all unreplaced template variables
 function themer_cleanup {
   local file=$1
 
-  sed --in-place '/{{!.*}}/d' $file &> /dev/null # delete whole line with unsubstituted {{!variable}}
+  sed -i -- '/{{!.*}}/d' $file &> /dev/null # delete whole line with unsubstituted {{!variable}}
+  sed -i -- -E -e 's/\{\{[^|]+\|//' -e 's/\}\}//' $file &> /dev/null # apply default values for unsubstituted variables
   sed -i -- 's/{{.*}}//g' $file &> /dev/null # delete unsubstituted variable {{variable}}
+
+  # remove temp file
+  rm "$file--"
 }
+


### PR DESCRIPTION
Accepted patterns:
```
  {{key}}                 Allow value to be substituted for "key"
  {{!key}}                Remove entire line if no value is substituted for "key"
  {{key|my_default}}      Use "my_default" if no value is substituted for "key"
  {{!key|my_default}}     (Nonsensical) Remove entire line if no value is substituted for "key"
```